### PR TITLE
Resizing of cards

### DIFF
--- a/src/components/bigButton/bigButton.module.scss
+++ b/src/components/bigButton/bigButton.module.scss
@@ -33,3 +33,10 @@
   background-color: $primaryButtonHover;
   cursor: pointer;
 }
+
+@media (max-width: 1024px) {
+  .bigButton {
+    height: 50px;
+    width: 180px;
+  }
+}

--- a/src/components/employeesCard/EmployeeCard.module.scss
+++ b/src/components/employeesCard/EmployeeCard.module.scss
@@ -1,6 +1,6 @@
 @import '../../layouts/variables';
 
-.EmployeeCard {
+.employeeCard {
   background-color: $white;
   border-radius: 15px;
   display: grid;
@@ -8,8 +8,6 @@
   grid-template-rows: 50% 50%;
   height: 300px;
   width: 358px;
-  transition: all 0.3s;
-  color: $grey;
   box-shadow: $newBoxShadow;
   padding: 25px;
   margin: 16px;
@@ -96,8 +94,18 @@
     display: flex;
     align-items: center;
   }
+}
 
-  p {
-    color: $dimGrey;
+@media (max-width: 814px) {
+  .employeeCard {
+    width: 310px;
+    grid-template-columns: 100px 160px;
+  }
+}
+
+@media (max-width: 690px) {
+  .employeeCard {
+    width: 358px;
+    grid-template-columns: 100px 200px;
   }
 }

--- a/src/components/employeesCard/index.js
+++ b/src/components/employeesCard/index.js
@@ -32,7 +32,7 @@ const iconMatcher = jobType => {
 const EmployeeCard = props => {
   const { name, jobTitle, description, jobType, portraitSize, image } = props;
   return (
-    <div className={styles.EmployeeCard}>
+    <div className={styles.employeeCard}>
       <div className={styles.imageAndIconContainer}>
         <ImageWrapper
           outerWrapperClassName={styles.imageContainer}

--- a/src/components/linkCard/linkCard.module.scss
+++ b/src/components/linkCard/linkCard.module.scss
@@ -8,7 +8,6 @@
   padding: $XL $L;
   border-radius: $S;
   box-shadow: $newBoxShadow;
-  transition: 0.3s;
 
   a {
     text-decoration: none;

--- a/src/components/perkCard/perkCard.module.scss
+++ b/src/components/perkCard/perkCard.module.scss
@@ -9,7 +9,6 @@
   display: flex;
   flex-flow: row wrap;
   box-shadow: 0 16px 16px 0 #c7d3e3;
-  transition: 0.3s;
   margin-bottom: $L;
   align-items: flex-start;
   margin: 16px;
@@ -26,6 +25,7 @@
     svg {
       font-size: 64px;
       color: $vibrantBlue;
+      width: 80px;
     }
 
     h4 {
@@ -34,28 +34,16 @@
   }
 }
 
-@media (max-width: 1172px) {
+@media (max-width: 814px) {
   .perkCard {
-    width: 325px;
+    width: 310px;
+    height: 268px;
   }
 }
 
-@media (max-width: 1024px) {
+@media (max-width: 690px) {
   .perkCard {
-    width: 243px;
-    height: 300px;
-  }
-}
-
-@media (max-width: 768px) {
-  .perkCard {
-    margin: 18px $XS;
-  }
-}
-
-@media (max-width: 712px) {
-  .perkCard {
-    width: 356px;
+    width: 358px;
     height: 221px;
   }
 }

--- a/src/templates/aboutPage/aboutPage.module.scss
+++ b/src/templates/aboutPage/aboutPage.module.scss
@@ -121,7 +121,7 @@
       max-width: 1170px;
 
       .quoteWrapper {
-        margin: 18px;
+        margin: 16px;
         padding-right: $M;
         height: 300px;
         width: 736px;
@@ -157,16 +157,13 @@
       }
 
       .employeeWrapper {
-        max-width: 800px;
-        justify-content: space-around;
+        max-width: 780px;
 
         .quoteWrapper {
           width: 350px;
 
           h2 {
-            width: 95%;
-            font-size: 1.75rem;
-            line-height: 2.5rem;
+            width: 100%;
           }
         }
       }
@@ -203,8 +200,34 @@
     .aboutEmployees {
       .employeeWrapper {
         grid-column: 1 / span 10;
-        max-width: 800px;
-        justify-content: center;
+      }
+    }
+  }
+}
+
+@media (max-width: 814px) {
+  .aboutPage {
+    .aboutEmployees {
+      .employeeWrapper {
+        max-width: 684px;
+
+        .quoteWrapper {
+          width: 310px;
+        }
+      }
+    }
+  }
+}
+
+@media (max-width: 690px) {
+  .aboutPage {
+    .aboutEmployees {
+      .employeeWrapper {
+        max-width: 375px;
+
+        .quoteWrapper {
+          display: none;
+        }
       }
     }
   }

--- a/src/templates/careerPage/careerPage.module.scss
+++ b/src/templates/careerPage/careerPage.module.scss
@@ -18,8 +18,6 @@
       grid-column: 3 / span 6;
 
       h1 {
-        width: 80%;
-        margin: auto;
         text-align: center;
       }
 
@@ -74,10 +72,6 @@
         border-bottom: 2px solid $vibrantBlue;
       }
 
-      h2 {
-        margin-top: $S;
-      }
-
       h2 + p {
         padding: $L 0;
       }
@@ -105,10 +99,6 @@
         padding-bottom: $M;
         margin-bottom: $XS;
         border-bottom: 2px solid $vibrantBlue;
-      }
-
-      h2 {
-        margin-top: $S;
       }
     }
 
@@ -190,12 +180,9 @@
           padding-bottom: $S;
         }
       }
-    }
 
-    .perks {
       .perkCardContainer {
-        max-width: 73%; // ca width of 8 columns
-        justify-content: center;
+        max-width: 780px;
       }
     }
 
@@ -234,6 +221,26 @@
   }
 }
 
+@media (max-width: 814px) {
+  .careerPage {
+    .perks {
+      .perkCardContainer {
+        max-width: 684px;
+      }
+    }
+  }
+}
+
+@media (max-width: 690px) {
+  .careerPage {
+    .perks {
+      .perkCardContainer {
+        max-width: 375px;
+      }
+    }
+  }
+}
+
 @media (max-width: 580px) {
   .careerPage {
     .hero,
@@ -241,11 +248,6 @@
     .perks {
       .textContainer {
         grid-column: 2 / span 8;
-      }
-
-      .perkCardContainer {
-        grid-column: 1 / span 10;
-        max-width: 100%;
       }
     }
 

--- a/src/templates/indexPage/indexPage.module.scss
+++ b/src/templates/indexPage/indexPage.module.scss
@@ -394,13 +394,6 @@
 
 @media (max-width: 1024px) {
   .homePage {
-    .animation {
-      p + a {
-        height: 50px;
-        width: 180px;
-      }
-    }
-
     .transition {
       .first {
         width: 114px;


### PR DESCRIPTION
EmployeeCards and PerkCards were still using justify-content: center when scaling down.
Changed this so they dont break the columns.
Also removed the transition, since it made the
resizing look weird.