### PR TITLE
Add meta description for search result snippets

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -229,7 +229,10 @@ export default class TemplateWrapper extends Component {
               src="//js.hs-scripts.com/2235598.js"
             />
           )}
-          <meta name="description" content="Investor tools and market data portals / Advanced features - simple set-up" />
+          <meta
+            name="description"
+            content="Investor tools and market data portals / Advanced features - simple set-up"
+          />
         </Helmet>
         <div className="grid">
           <Navbar

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -229,7 +229,7 @@ export default class TemplateWrapper extends Component {
               src="//js.hs-scripts.com/2235598.js"
             />
           )}
-          <meta name="description" content="Investor tools and market data portals / Advanced features - simple set-up">
+          <meta name="description" content="Investor tools and market data portals / Advanced features - simple set-up" />
         </Helmet>
         <div className="grid">
           <Navbar

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -229,6 +229,7 @@ export default class TemplateWrapper extends Component {
               src="//js.hs-scripts.com/2235598.js"
             />
           )}
+          <meta name="description" content="Investor tools and market data portals / Advanced features - simple set-up">
         </Helmet>
         <div className="grid">
           <Navbar


### PR DESCRIPTION
This will suggest a page description as an option for search engines to
use in results. Some searches will currently use text with cookie info
because this is the very first DOM content with text on the page.

Search engines will create snippets automatically from content, so this
meta description can’t be forced, but hopefully persuade as more
relevant infromation to display than “Cookie settings” 🍪

![search-snippet-cookies](https://user-images.githubusercontent.com/6517834/74460381-17826c00-4e8d-11ea-81cc-ee7c5ad42186.png)

---

> Snippets are designed to emphasize and preview the page content that 
> best relates to a user's specific search: this means that a page might 
> show different snippets for different searches. 

More details on [support.google.com/webmasters](https://support.google.com/webmasters/answer/35624)

Maybe we can look into **changing the source order**, but this is a quick win.